### PR TITLE
add ex command called 'iunmap'

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -61,6 +61,16 @@ export default class VimrcPlugin extends Plugin {
 						}
 					}
 				)
+
+				vimCommands.split("\n").forEach(
+					function (line, index, arr) {
+						var words = line.split(/\s+/, 2)
+						if (line.trim().length > 0 && line.trim()[0] != '"' && words[0] == 'iunmap') {
+							CodeMirror.Vim.unmap(words[1], 'insert');
+						}
+					}
+				)
+
 				// Make sure that we load it just once per CodeMirror instance.
 				// This is supposed to work because the Vim state is kept at the keymap level, hopefully
 				// there will not be bugs caused by operations that are kept at the object level instead

--- a/main.ts
+++ b/main.ts
@@ -54,19 +54,17 @@ export default class VimrcPlugin extends Plugin {
 					}
 				});
 
+				CodeMirror.Vim.defineEx('iunmap', '', function (cm, params) => {
+					if (params.argString.trim()) {
+						CodeMirror.Vim.unmap(params.argString.trim(), 'insert');
+						// console.log("ex command, iunmap executed: " + params.argString.trim());
+					}
+				});
+
 				vimCommands.split("\n").forEach(
 					function(line, index, arr) {
 						if (line.trim().length > 0 && line.trim()[0] != '"') {
 							CodeMirror.Vim.handleEx(cmEditor, line);
-						}
-					}
-				)
-
-				vimCommands.split("\n").forEach(
-					function (line, index, arr) {
-						var words = line.split(/\s+/, 2)
-						if (line.trim().length > 0 && line.trim()[0] != '"' && words[0] == 'iunmap') {
-							CodeMirror.Vim.unmap(words[1], 'insert');
 						}
 					}
 				)


### PR DESCRIPTION
- `iunmap` command added
- assumed to describe like `iummap <C-d>` in `.obsidian.vimrc`
- separated from `CodeMirror.Vim.handleEx()` function block

associated with https://github.com/esm7/obsidian-vimrc-support/issues/8