### PR TITLE
Add noremap

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { App, Plugin, TFile, MarkdownView } from 'obsidian';
+declare const CodeMirror: any;
 
 export default class VimrcPlugin extends Plugin {
 	private lastYankBuffer = new Array<string>(0);
@@ -57,6 +58,16 @@ export default class VimrcPlugin extends Plugin {
 				CodeMirror.Vim.defineEx('iunmap', '', (cm, params) => {
 					if (params.argString.trim()) {
 						CodeMirror.Vim.unmap(params.argString.trim(), 'insert');
+					}
+				});
+
+				CodeMirror.Vim.defineEx('noremap', '', (cm, params) => {
+					if (!params?.args?.length) {
+						throw new Error('Invalid mapping: noremap');
+					}
+				
+					if (params.argString.trim()) {
+						CodeMirror.Vim.noremap.apply(CodeMirror.Vim, params.args);
 					}
 				});
 


### PR DESCRIPTION
Adds Code Mirror's noremap command as an ExCommand to enable its use in vimrc

Thanks for the plugin! By the way, I created a relative line number plugin: https://github.com/nadavspi/obsidian-relative-line-numbers