### PR TITLE
Vim mode and chord display, cleanup, surround, pasteinto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.iml
 .idea
 
+# My deployment script
+*.sh
+
 # npm
 node_modules
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In addition to that:
 - Custom mapping/unmapping commands in addition to the defaults: `noremap` and `iunmap` (PRs are welcome to implement more :) )
 - `exmap [commandName] [command...]`: a command to map Ex commands. This should basically be supported in regular `:map`, but doesn't work with multi-argument commands due to a CodeMirror bug, so this is a workaround.
 - `obcommand` - execute Obsidian commands, see more details below.
+- `surround` - surround your selected text in visual mode with text.
 
 Commands that fail don't generate any visible error for now.
 
@@ -97,6 +98,26 @@ And many more.
 **WARNING:** this is not a formal API that Obsidian provides and is done in a rather hacky manner.
 It's definitely possible that some future version of Obsidian will break this functionality.
 
+## Surround Text with `surround`
+
+The plugin defines a custom Ex command named `surround` to surround either your currently selected text in visual mode or the word your cursor is over with text.
+This is particularly useful for creating wikilinks in Obsidian `[[WikiLink]]`.
+
+The syntax follows `:surround [prefixText] [postfixText]`.
+
+Some examples:
+- `surround ( )`
+- `surround [[ ]]`
+
+Here's my surround config as an example:
+
+```
+" Surround text with [[ ]] to make a wikilink
+" NOTE: must use 'map' and not 'nmap'
+exmap wiki surround [[ ]]
+map [[ :wiki
+```
+
 ### Mapping Obsidian Commands Within Vim
 
 Next thing you probably wanna ask is "how do I map the great Obsidian commands to Vim commands?"
@@ -114,6 +135,12 @@ nmap <C-o> :back
 ```
 
 Note how `exmap` lists command names without colons and in `nmap` the colon is required.
+
+## Some Help with Binding Space Chords (Doom and Spacemacs fans)
+
+`<Space>` can be bound to make chords, such as `<Space>fs` in conjunction with obcommand to save your current file and more.
+But first `<Space>` must be unbound with `unmap <Space>`.
+Otherwise `<Space>` can be mapped normally as any other key.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ In addition to that:
 - Custom mapping/unmapping commands in addition to the defaults: `noremap` and `iunmap` (PRs are welcome to implement more :) )
 - `exmap [commandName] [command...]`: a command to map Ex commands. This should basically be supported in regular `:map`, but doesn't work with multi-argument commands due to a CodeMirror bug, so this is a workaround.
 - `obcommand` - execute Obsidian commands, see more details below.
-- `surround` - surround your selected text in visual mode with text.
+- `surround` - surround your selected text in visual mode or word in normal mode with text.
+- `pasteinto` - paste your current clipboard into your selected text in visual mode or word in normal mode. Useful for creating hyperlinks.
 
 Commands that fail don't generate any visible error for now.
 
@@ -100,7 +101,7 @@ It's definitely possible that some future version of Obsidian will break this fu
 
 ## Surround Text with `surround`
 
-The plugin defines a custom Ex command named `surround` to surround either your currently selected text in visual mode or the word your cursor is over with text.
+The plugin defines a custom Ex command named `surround` to surround either your currently selected text in visual mode or the word your cursor is over in normal mode with text.
 This is particularly useful for creating wikilinks in Obsidian `[[WikiLink]]`.
 
 The syntax follows `:surround [prefixText] [postfixText]`.
@@ -116,6 +117,17 @@ Here's my surround config as an example:
 " NOTE: must use 'map' and not 'nmap'
 exmap wiki surround [[ ]]
 map [[ :wiki
+```
+
+## Inserting Links/Hyperlinks with `pasteinto`
+
+The plugin defines a custom Ex command named `pasteinto` to paste text into your currently selected text in visual mode, or the word your cursor is over in normal mode.
+This is particularly useful for creating links/hyperlinks `[selected-text](paste)`.
+
+Here's my hyperlink config as an example:
+```
+" Maps pasteinto to Alt-p
+map <A-p> :pasteinto
 ```
 
 ### Mapping Obsidian Commands Within Vim
@@ -140,7 +152,7 @@ Note how `exmap` lists command names without colons and in `nmap` the colon is r
 
 `<Space>` can be bound to make chords, such as `<Space>fs` in conjunction with obcommand to save your current file and more.
 But first `<Space>` must be unbound with `unmap <Space>`.
-Otherwise `<Space>` can be mapped normally as any other key.
+Afterwards `<Space>` can be mapped normally as any other key.
 
 ## Changelog
 

--- a/main.ts
+++ b/main.ts
@@ -101,12 +101,6 @@ export default class VimrcPlugin extends Plugin {
 					}
 				});
 
-				CodeMirror.Vim.defineOption('displayChord', 4, 'number', [], (value: number, cm: any) => {
-					if (value) {
-						cmEditor.setOption('tabSize', value);
-					}
-				});
-
 				CodeMirror.Vim.defineEx('iunmap', '', (cm: any, params: any) => {
 					if (params.argString.trim()) {
 						CodeMirror.Vim.unmap(params.argString.trim(), 'insert');

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
   "description": "Auto-load a startup file with Obsidian Vim commands.",
   "author": "esm",
   "authorUrl": "",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }


### PR DESCRIPTION
 - Added display for the current vim mode and chord that's being input.
 - Added settings page for both vim mode display and chord display.
 - Changed to desktop only application due to the deprecation of cmEditor.

The current location of the chord display isn't exactly the best, so I'm up to move it anywhere that could be better.
I'm inexperienced with Typescript and Javascript, so it's not unlikely that I followed some bad practices. Please point anything bad out.