### PR TITLE
Several fixes to CodeMirror event registration

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -84,6 +84,10 @@ export default class VimrcPlugin extends Plugin {
 		}));
 
 		this.app.workspace.on('codemirror', (cm: CodeMirror.Editor) => {
+			cm.on('vim-mode-change', (modeObj: any) => {
+				if (modeObj)
+					this.logVimModeChange(modeObj);
+			});
 			this.defineFixedLayout(cm);
 		});
 
@@ -125,6 +129,8 @@ export default class VimrcPlugin extends Plugin {
 			default:
 				break;
 		}
+		if (this.settings.displayVimMode) 
+			this.vimStatusBar.setText(this.currentVimStatus); // TODO save status by leaf instead and add update on-leaf-change.
 	}
 
 	onunload() {
@@ -437,15 +443,6 @@ export default class VimrcPlugin extends Plugin {
 		if (this.settings.displayVimMode) {
 			this.vimStatusBar = this.addStatusBarItem() // Add status bar item
 			this.vimStatusBar.setText(vimStatus.normal) // Init the vimStatusBar with normal mode
-			// Register vim-mode-change event for all current and future CodeMirror.Editor instances.
-			this.registerCodeMirror((cm: CodeMirror.Editor) => {
-				CodeMirror.on(cm, 'vim-mode-change', (modeObj: any) => {
-					if (modeObj) {
-						this.logVimModeChange(modeObj);
-						this.vimStatusBar.setText(this.currentVimStatus); // TODO save status by leaf instead and add update on-leaf-change.
-					}
-				});
-			});
 		}
 	}
 


### PR DESCRIPTION
Fixed problem with the chord display only keeping track of one CodeMirror instance.
Previously, chords would only be tracked in one CodeMirror instance.

Fixed problem with surround command surrounding text in incorrect locations (related: #39).
Previously, selections wouldn't update in any other instance than the main CodeMirror instance, causing the surround excommand to surround incorrect text. Now the selections are updated across multiple CodeMirror instances.

Both fixes applied by wrapping the CodeMirror event registers in `registerCodeMirror()` so that all future CodeMirror instances will be registered to the events (cursorActivity, vim-mode-change, vim-keypress, and vim-command-done when applicable).