### PR TITLE
Use register event

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -104,8 +104,7 @@ export default class VimrcPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 		this.addSettingTab(new SettingsTab(this.app, this))
-
-		this.app.workspace.on('file-open', async (file: TFile) => {
+		this.registerEvent(this.app.workspace.on('file-open', async (file: TFile) => {
 			if (!this.initialized)
 				await this.initialize();
 			let fileName = this.settings.vimrcFileName;
@@ -120,7 +119,7 @@ export default class VimrcPlugin extends Plugin {
 				console.log('Error loading vimrc file', fileName, 'from the vault root', e.message) 
 			}
 			this.readVimInit(vimrcContent);
-		});
+		}));
 	}
 
 	async loadSettings() {


### PR DESCRIPTION
Attempting to troubleshoot https://github.com/esm7/obsidian-vimrc-support/issues/122, where certain other plugins non-deterministically cause vimrc loading not to occur.

Could someone test this and see if it addresses the issue? Reproducing the bug in the first place is non-deterministic on my system, so I can't be sure this is even working, but it seems like the general expectation for Obsidian Plugins is they should register event handlers, so I'm guessing what happens is that if other plugins register handlers for the `file-open` event, they can prevent this plugin from seeing the event when it fires, and therefore it never loads the vimrc.