### PR TITLE
Allow customized Vim mode prompt text on status bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ main.js
 data.json
 
 obsidian.d.ts
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ The `data-vim-mode` values:
 
 #### Powerline Styling Snippet
 
+**Screenshots**
+
+<img width="1470" alt="Screen Shot 2023-04-09 at 19 19 53" src="https://user-images.githubusercontent.com/11176415/230812728-731e24d3-d667-478c-831c-14e0010e7973.png">
+<img width="1470" alt="Screen Shot 2023-04-09 at 19 20 09" src="https://user-images.githubusercontent.com/11176415/230812731-26ba0c02-1948-4a26-89d2-3e73a11076d1.png">
+<img width="1470" alt="Screen Shot 2023-04-09 at 19 20 22" src="https://user-images.githubusercontent.com/11176415/230812734-f51a01c9-5f80-4da7-b051-04018cc805cc.png">
+<img width="1470" alt="Screen Shot 2023-04-09 at 19 20 37" src="https://user-images.githubusercontent.com/11176415/230812736-6fa688db-37b9-4b70-bacb-a6553b0762cb.png">
+
 ```css
 div.status-bar-item.plugin-obsidian-vimrc-support {
   /* Papercolor theme */

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ nmap [[ :prevHeading
 
 See [here](JsSnippets.md) for the full example, and please contribute your own!
 
+### Custom Styles for Status Bar
+
+You may utilize the following CSS class names to add styles to the status bar prompt
+(e.g. assign colors for different status).
+
+| Mode    | Class Name                                     |
+| ------- | ---------------------------------------------- |
+| normal  | `plugin-obsidian-vimrc-support-prompt-normal`  |
+| insert  | `plugin-obsidian-vimrc-support-prompt-insert`  |
+| visual  | `plugin-obsidian-vimrc-support-prompt-visual`  |
+| replace | `plugin-obsidian-vimrc-support-prompt-replace` |
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ also toggle the setting in settings page to also apply the display prompt class 
 entire status bar container if you want some customizations on it.
 
 The display prompt class: `vimrc-support-vim-mode`
+
 The `data-vim-mode` values:
 
 | Mode    | Data Value (`data-vim-mode`) |

--- a/README.md
+++ b/README.md
@@ -285,15 +285,20 @@ See [here](JsSnippets.md) for the full example, and please contribute your own!
 
 ### Custom Styles for Status Bar
 
-You may utilize the following CSS class names to add styles to the status bar prompt
-(e.g. assign colors for different status).
+You may utilize the vim mode display prompt class and the `data-vim-mode` attribute to 
+add styles to the status bar prompt (e.g. assign colors for different status). You can 
+also toggle the setting in settings page to also apply the display prompt class to the 
+entire status bar container if you want some customizations on it.
 
-| Mode    | Class Name                                     |
-| ------- | ---------------------------------------------- |
-| normal  | `plugin-obsidian-vimrc-support-prompt-normal`  |
-| insert  | `plugin-obsidian-vimrc-support-prompt-insert`  |
-| visual  | `plugin-obsidian-vimrc-support-prompt-visual`  |
-| replace | `plugin-obsidian-vimrc-support-prompt-replace` |
+The display prompt class: `vimrc-support-vim-mode`
+The `data-vim-mode` values:
+
+| Mode    | Data Value (`data-vim-mode`) |
+| ------- | ---------------------------- |
+| normal  | `normal`                     |
+| insert  | `insert`                     |
+| visual  | `visual`                     |
+| replace | `replace`                    |
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,97 @@ The `data-vim-mode` values:
 | visual  | `visual`                     |
 | replace | `replace`                    |
 
+#### Powerline Styling Snippet
+
+```css
+div.status-bar-item.plugin-obsidian-vimrc-support {
+  /* Papercolor theme */
+  --text-color-normal: #585858;
+  --text-color-insert: #005f87;
+  --text-color-visual: white;
+  --text-color-replace: white;
+
+  --background-color-normal: #eeeeee;
+  --background-color-insert: #eeeeee;
+  --background-color-visual: #d75f00;
+  --background-color-replace: #d70087;
+}
+
+div.status-bar-item.plugin-obsidian-vimrc-support {
+  /* 
+    Move to bottom left corner and discard top/left/bottom space
+    from container paddings.
+   */
+  order: -9999;
+  margin: -4px auto -5px -5px;
+
+  /* 
+    We have the :after pseudo-element next, so padding-right
+    is not needed
+    */
+  padding-right: 0px;
+  padding-left: 1em;
+
+  /* Use Monospace font */
+  font-family: 'MesloLGM Nerd Font Mono'; /* !!! Needs to be a powerline font */
+  font-weight: bold;
+  font-size: 1.2em;
+
+  /* Clear spaces made from radius borders */
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+div.status-bar-item.plugin-obsidian-vimrc-support:after {
+  /* Powerline separator character */
+  content: '';
+  position: relative;
+  font-size: 1.5rem;
+  left: 0.9rem;
+
+  /* Fine adjust the position */
+  margin-top: 0.1rem;
+}
+
+/* Normal */
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="normal"]:after {
+  color: var(--background-color-normal);
+}
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="normal"] {
+  color: var(--text-color-normal);
+  background-color: var(--background-color-normal);
+}
+
+/* Insert */
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="insert"]:after {
+  color: var(--background-color-insert);
+}
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="insert"] {
+  color: var(--text-color-insert);
+  background-color: var(--background-color-insert);
+}
+
+/* Visual */
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="visual"]:after {
+  color: var(--background-color-visual);
+}
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="visual"] {
+  color: var(--text-color-visual);
+  background-color: var(--background-color-visual);
+}
+
+/* Replace */
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="replace"]:after {
+  color: var(--background-color-replace);
+}
+div.status-bar-item.vimrc-support-vim-mode[data-vim-mode="replace"] {
+  color: var(--text-color-replace);
+  background-color: var(--background-color-replace);
+}
+```
+
+Note that the above snippet uses powerline glygh for the triangular shape, so you need to install a [powerline font](https://github.com/powerline/fonts) to display correctly. And of course, feel free to change the CSS variables to whatever color palette you want!
+
 ## Changelog
 
 ### 0.9.0

--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,7 @@ interface Settings {
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
 	vimStatusPromptMap: VimStatusPromptMap;
+	vimModeStatusBarCSSClass: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -37,6 +38,7 @@ const DEFAULT_SETTINGS: Settings = {
 		visual: '🟡',
 		replace: '🔴',
 	},
+	vimModeStatusBarCSSClass: false,
 }
 
 const vimStatusPromptClassNameMap = {
@@ -83,6 +85,12 @@ export default class VimrcPlugin extends Plugin {
 		this.vimStatusBar?.setText(
 			this.settings.vimStatusPromptMap[this.currentVimStatus]
 		);
+		if (this.settings.vimModeStatusBarCSSClass) {
+			document.querySelector('div.status-bar')?.classList.replace(
+				this.currentVimStatusClassName,
+				vimStatusPromptClassNameMap[this.currentVimStatus]
+			);
+		}
 		this.vimStatusBar?.classList.replace(
 			this.currentVimStatusClassName,
 			vimStatusPromptClassNameMap[this.currentVimStatus]
@@ -617,6 +625,11 @@ export default class VimrcPlugin extends Plugin {
 			this.vimStatusBar.setText(
 				this.settings.vimStatusPromptMap[vimStatus.normal]
 			); // Init the vimStatusBar with normal mode
+			if (this.settings.vimModeStatusBarCSSClass) {
+				document.querySelector('div.status-bar')?.addClass(
+					vimStatusPromptClassNameMap[vimStatus.normal]
+				);
+			}
 			this.vimStatusBar?.addClass(
 				vimStatusPromptClassNameMap[vimStatus.normal]
 			); // Add the initial class name for normal mode
@@ -782,6 +795,23 @@ class SettingsTab extends PluginSettingTab {
 			});
 
 		containerEl.createEl('hr');
+
+		new Setting(containerEl)
+			.setName('Add Vim mode class to status bar')
+			.setDesc(
+				'Also add corresponding CSS class to status bar when Vim mode changes. ' +
+				'This allows powerline-ish styling on the whole status bar (requires restart).'
+			)
+			.addToggle(toggle => {
+				toggle.setValue(
+					this.plugin.settings.vimModeStatusBarCSSClass ??
+					DEFAULT_SETTINGS.vimModeStatusBarCSSClass
+				);
+				toggle.onChange(value => {
+					this.plugin.settings.vimModeStatusBarCSSClass = value;
+					this.plugin.saveSettings();
+				})
+			});
 
 		new Setting(containerEl)
 			.setName('Normal mode prompt')

--- a/main.ts
+++ b/main.ts
@@ -793,7 +793,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.normal
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.normal = value;
+					this.plugin.settings.vimStatusPromptMap.normal = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.normal;
 					this.plugin.saveSettings();
 				});
 			});
@@ -808,7 +809,9 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.insert
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.insert = value;
+					this.plugin.settings.vimStatusPromptMap.insert = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.insert;
+					console.log(this.plugin.settings.vimStatusPromptMap);
 					this.plugin.saveSettings();
 				});
 			});
@@ -823,7 +826,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.visual
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.visual = value;
+					this.plugin.settings.vimStatusPromptMap.visual = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.visual;
 					this.plugin.saveSettings();
 				});
 			});
@@ -838,7 +842,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.replace
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.replace = value;
+					this.plugin.settings.vimStatusPromptMap.replace = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.replace;
 					this.plugin.saveSettings();
 				});
 			});

--- a/main.ts
+++ b/main.ts
@@ -4,14 +4,14 @@ import { EditorSelection, Notice, App, MarkdownView, Plugin, PluginSettingTab, S
 declare const CodeMirror: any;
 
 const enum vimStatus {
-  normal = 'normal',
-  insert = 'insert',
-  visual = 'visual',
-  replace = 'replace',
+	normal = 'normal',
+	insert = 'insert',
+	visual = 'visual',
+	replace = 'replace',
 }
 type VimStatusPrompt = string;
 type VimStatusPromptMap = {
-  [status in vimStatus]: VimStatusPrompt;
+	[status in vimStatus]: VimStatusPrompt;
 };
 
 interface Settings {
@@ -21,7 +21,7 @@ interface Settings {
 	fixedNormalModeLayout: boolean,
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
-  vimStatusPromptMap: VimStatusPromptMap;
+	vimStatusPromptMap: VimStatusPromptMap;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -31,19 +31,19 @@ const DEFAULT_SETTINGS: Settings = {
 	fixedNormalModeLayout: false,
 	capturedKeyboardMap: {},
 	supportJsCommands: false,
-  vimStatusPromptMap: {
-    normal: '🟢',
-    insert: '🟠',
-    visual: '🟡',
-    replace: '🔴',
-  },
+	vimStatusPromptMap: {
+		normal: '🟢',
+		insert: '🟠',
+		visual: '🟡',
+		replace: '🔴',
+	},
 }
 
 const vimStatusPromptClassNameMap = {
-  normal: 'plugin-obsidian-vimrc-support-prompt-normal',
-  insert: 'plugin-obsidian-vimrc-support-prompt-insert',
-  visual: 'plugin-obsidian-vimrc-support-prompt-visual',
-  replace: 'plugin-obsidian-vimrc-support-prompt-replace',
+	normal: 'plugin-obsidian-vimrc-support-prompt-normal',
+	insert: 'plugin-obsidian-vimrc-support-prompt-insert',
+	visual: 'plugin-obsidian-vimrc-support-prompt-visual',
+	replace: 'plugin-obsidian-vimrc-support-prompt-replace',
 }
 
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
@@ -73,23 +73,23 @@ export default class VimrcPlugin extends Plugin {
 	private vimChordStatusBar: HTMLElement = null;
 	private vimStatusBar: HTMLElement = null;
 	private currentVimStatus: vimStatus = vimStatus.normal;
-  private currentVimStatusClassName: string = 
-    vimStatusPromptClassNameMap[vimStatus.normal];
+	private currentVimStatusClassName: string = 
+		vimStatusPromptClassNameMap[vimStatus.normal];
 	private customVimKeybinds: { [name: string]: boolean } = {};
 	private currentSelection: [EditorSelection] = null;
 	private isInsertMode: boolean = false;
 
-  updateVimStatusBar() {
-    this.vimStatusBar?.setText(
-      this.settings.vimStatusPromptMap[this.currentVimStatus]
-    );
-    this.vimStatusBar?.classList.replace(
-      this.currentVimStatusClassName,
-      vimStatusPromptClassNameMap[this.currentVimStatus]
-    );
-    this.currentVimStatusClassName = 
-      vimStatusPromptClassNameMap[this.currentVimStatus];
-  }
+	updateVimStatusBar() {
+		this.vimStatusBar?.setText(
+			this.settings.vimStatusPromptMap[this.currentVimStatus]
+		);
+		this.vimStatusBar?.classList.replace(
+			this.currentVimStatusClassName,
+			vimStatusPromptClassNameMap[this.currentVimStatus]
+		);
+		this.currentVimStatusClassName = 
+			vimStatusPromptClassNameMap[this.currentVimStatus];
+	}
 
 	async captureKeyboardLayout() {
 		// This is experimental API and it might break at some point:
@@ -179,7 +179,7 @@ export default class VimrcPlugin extends Plugin {
 			this.isInsertMode = false;
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
-        this.updateVimStatusBar();
+				this.updateVimStatusBar();
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
 
@@ -248,7 +248,7 @@ export default class VimrcPlugin extends Plugin {
 				break;
 		}
 		if (this.settings.displayVimMode)
-      this.updateVimStatusBar();
+			this.updateVimStatusBar();
 	}
 
 	onunload() {
@@ -276,7 +276,7 @@ export default class VimrcPlugin extends Plugin {
 				this.defineJsFile(this.codeMirrorVimObject);
 				this.defineSource(this.codeMirrorVimObject);
 
-        this.loadVimCommands(vimCommands);
+				this.loadVimCommands(vimCommands);
 
 				this.prepareChordDisplay();
 				this.prepareVimModeDisplay();
@@ -614,12 +614,12 @@ export default class VimrcPlugin extends Plugin {
 	prepareVimModeDisplay() {
 		if (this.settings.displayVimMode) {
 			this.vimStatusBar = this.addStatusBarItem() // Add status bar item
-      this.vimStatusBar.setText(
-        this.settings.vimStatusPromptMap[vimStatus.normal]
-      ); // Init the vimStatusBar with normal mode
-      this.vimStatusBar?.addClass(
-        vimStatusPromptClassNameMap[vimStatus.normal]
-      ); // Add the initial class name for normal mode
+			this.vimStatusBar.setText(
+				this.settings.vimStatusPromptMap[vimStatus.normal]
+			); // Init the vimStatusBar with normal mode
+			this.vimStatusBar?.addClass(
+				vimStatusPromptClassNameMap[vimStatus.normal]
+			); // Add the initial class name for normal mode
 		}
 	}
 
@@ -781,64 +781,64 @@ class SettingsTab extends PluginSettingTab {
 				})
 			});
 
-    new Setting(containerEl)
-      .setName('Normal mode prompt')
-      .setDesc('Set the status prompt text for normal mode.')
-      .addText((text) => {
-        text.setPlaceholder('Default: 🟢');
-        text.setValue(
-          this.plugin.settings.vimStatusPromptMap.normal ||
-            DEFAULT_SETTINGS.vimStatusPromptMap.normal
-        );
-        text.onChange((value) => {
-          this.plugin.settings.vimStatusPromptMap.normal = value;
-          this.plugin.saveSettings();
-        });
-      });
+		new Setting(containerEl)
+			.setName('Normal mode prompt')
+			.setDesc('Set the status prompt text for normal mode.')
+			.addText((text) => {
+				text.setPlaceholder('Default: 🟢');
+				text.setValue(
+					this.plugin.settings.vimStatusPromptMap.normal ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.normal
+				);
+				text.onChange((value) => {
+					this.plugin.settings.vimStatusPromptMap.normal = value;
+					this.plugin.saveSettings();
+				});
+			});
 
-    new Setting(containerEl)
-      .setName('Insert mode prompt')
-      .setDesc('Set the status prompt text for insert mode.')
-      .addText((text) => {
-        text.setPlaceholder('Default: 🟠');
-        text.setValue(
-          this.plugin.settings.vimStatusPromptMap.insert ||
-            DEFAULT_SETTINGS.vimStatusPromptMap.insert
-        );
-        text.onChange((value) => {
-          this.plugin.settings.vimStatusPromptMap.insert = value;
-          this.plugin.saveSettings();
-        });
-      });
+		new Setting(containerEl)
+			.setName('Insert mode prompt')
+			.setDesc('Set the status prompt text for insert mode.')
+			.addText((text) => {
+				text.setPlaceholder('Default: 🟠');
+				text.setValue(
+					this.plugin.settings.vimStatusPromptMap.insert ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.insert
+				);
+				text.onChange((value) => {
+					this.plugin.settings.vimStatusPromptMap.insert = value;
+					this.plugin.saveSettings();
+				});
+			});
 
-    new Setting(containerEl)
-      .setName('Visual mode prompt')
-      .setDesc('Set the status prompt text for visual mode.')
-      .addText((text) => {
-        text.setPlaceholder('Default: 🟡');
-        text.setValue(
-          this.plugin.settings.vimStatusPromptMap.visual ||
-            DEFAULT_SETTINGS.vimStatusPromptMap.visual
-        );
-        text.onChange((value) => {
-          this.plugin.settings.vimStatusPromptMap.visual = value;
-          this.plugin.saveSettings();
-        });
-      });
+		new Setting(containerEl)
+			.setName('Visual mode prompt')
+			.setDesc('Set the status prompt text for visual mode.')
+			.addText((text) => {
+				text.setPlaceholder('Default: 🟡');
+				text.setValue(
+					this.plugin.settings.vimStatusPromptMap.visual ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.visual
+				);
+				text.onChange((value) => {
+					this.plugin.settings.vimStatusPromptMap.visual = value;
+					this.plugin.saveSettings();
+				});
+			});
 
-    new Setting(containerEl)
-      .setName('Replace mode prompt')
-      .setDesc('Set the status prompt text for replace mode.')
-      .addText((text) => {
-        text.setPlaceholder('Default: 🔴');
-        text.setValue(
-          this.plugin.settings.vimStatusPromptMap.replace ||
-            DEFAULT_SETTINGS.vimStatusPromptMap.replace
-        );
-        text.onChange((value) => {
-          this.plugin.settings.vimStatusPromptMap.replace = value;
-          this.plugin.saveSettings();
-        });
-      });
+		new Setting(containerEl)
+			.setName('Replace mode prompt')
+			.setDesc('Set the status prompt text for replace mode.')
+			.addText((text) => {
+				text.setPlaceholder('Default: 🔴');
+				text.setValue(
+					this.plugin.settings.vimStatusPromptMap.replace ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.replace
+				);
+				text.onChange((value) => {
+					this.plugin.settings.vimStatusPromptMap.replace = value;
+					this.plugin.saveSettings();
+				});
+			});
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -22,7 +22,6 @@ interface Settings {
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
 	vimStatusPromptMap: VimStatusPromptMap;
-	vimModeStatusBarCSSClass: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -38,7 +37,6 @@ const DEFAULT_SETTINGS: Settings = {
 		visual: '🟡',
 		replace: '🔴',
 	},
-	vimModeStatusBarCSSClass: false,
 }
 
 const vimStatusPromptClass = "vimrc-support-vim-mode";
@@ -78,13 +76,6 @@ export default class VimrcPlugin extends Plugin {
 		this.vimStatusBar.setText(
 			this.settings.vimStatusPromptMap[this.currentVimStatus]
 		);
-		if (this.settings.vimModeStatusBarCSSClass) {
-			// When the setting is on, we also update vim status for the status bar
-			// container element.
-			(
-				document.querySelector("div.status-bar") as HTMLElement
-			).dataset.vimMode = this.currentVimStatus;
-		}
 		this.vimStatusBar.dataset.vimMode = this.currentVimStatus;
 	}
 
@@ -614,14 +605,6 @@ export default class VimrcPlugin extends Plugin {
 			this.vimStatusBar.setText(
 				this.settings.vimStatusPromptMap[vimStatus.normal]
 			); // Init the vimStatusBar with normal mode
-			if (this.settings.vimModeStatusBarCSSClass) {
-				// When the setting is on, we also add the display prompt class to the
-				// status bar container element.
-				document.querySelector('div.status-bar').addClass(vimStatusPromptClass);
-				(
-					document.querySelector('div.status-bar') as HTMLElement
-				).dataset.vimMode = this.currentVimStatus;
-			}
 			this.vimStatusBar.addClass(vimStatusPromptClass);
 			this.vimStatusBar.dataset.vimMode = this.currentVimStatus;
 		}
@@ -786,23 +769,6 @@ class SettingsTab extends PluginSettingTab {
 			});
 
 		containerEl.createEl('h2', {text: 'Vim Mode Display Prompt'});
-
-		new Setting(containerEl)
-			.setName('Add Vim mode class to status bar')
-			.setDesc(
-				'Also add corresponding CSS class to status bar when Vim mode changes. ' +
-				'This allows powerline-ish styling on the whole status bar (requires restart).'
-			)
-			.addToggle(toggle => {
-				toggle.setValue(
-					this.plugin.settings.vimModeStatusBarCSSClass ??
-					DEFAULT_SETTINGS.vimModeStatusBarCSSClass
-				);
-				toggle.onChange(value => {
-					this.plugin.settings.vimModeStatusBarCSSClass = value;
-					this.plugin.saveSettings();
-				})
-			});
 
 		new Setting(containerEl)
 			.setName('Normal mode prompt')

--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,17 @@ import { EditorSelection, Notice, App, MarkdownView, Plugin, PluginSettingTab, S
 
 declare const CodeMirror: any;
 
+const enum vimStatus {
+  normal = 'normal',
+  insert = 'insert',
+  visual = 'visual',
+  replace = 'replace',
+}
+type VimStatusPrompt = string;
+type VimStatusPromptMap = {
+  [status in vimStatus]: VimStatusPrompt;
+};
+
 interface Settings {
 	vimrcFileName: string,
 	displayChord: boolean,
@@ -10,6 +21,7 @@ interface Settings {
 	fixedNormalModeLayout: boolean,
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
+  vimStatusPromptMap: VimStatusPromptMap;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -18,14 +30,13 @@ const DEFAULT_SETTINGS: Settings = {
 	displayVimMode: false,
 	fixedNormalModeLayout: false,
 	capturedKeyboardMap: {},
-	supportJsCommands: false
-}
-
-const enum vimStatus {
-	normal = "🟢",
-	insert = "🟠",
-	replace = "🔴",
-	visual = "🟡"
+	supportJsCommands: false,
+  vimStatusPromptMap: {
+    normal: '🟢',
+    insert: '🟠',
+    visual: '🟡',
+    replace: '🔴',
+  },
 }
 
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
@@ -147,7 +158,9 @@ export default class VimrcPlugin extends Plugin {
 			this.isInsertMode = false;
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
-				this.vimStatusBar?.setText(this.currentVimStatus);
+        this.vimStatusBar?.setText(
+          this.settings.vimStatusPromptMap[this.currentVimStatus]
+        );
 
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
@@ -217,7 +230,9 @@ export default class VimrcPlugin extends Plugin {
 				break;
 		}
 		if (this.settings.displayVimMode)
-			this.vimStatusBar?.setText(this.currentVimStatus);
+      this.vimStatusBar?.setText(
+        this.settings.vimStatusPromptMap[this.currentVimStatus]
+      );
 	}
 
 	onunload() {
@@ -583,7 +598,9 @@ export default class VimrcPlugin extends Plugin {
 	prepareVimModeDisplay() {
 		if (this.settings.displayVimMode) {
 			this.vimStatusBar = this.addStatusBarItem() // Add status bar item
-			this.vimStatusBar.setText(vimStatus.normal) // Init the vimStatusBar with normal mode
+      this.vimStatusBar.setText(
+        this.settings.vimStatusPromptMap[vimStatus.normal]
+      ); // Init the vimStatusBar with normal mode
 		}
 	}
 
@@ -744,5 +761,65 @@ class SettingsTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				})
 			});
+
+    new Setting(containerEl)
+      .setName('Normal mode prompt')
+      .setDesc('Set the status prompt text for normal mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟢');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.normal ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.normal
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.normal = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Insert mode prompt')
+      .setDesc('Set the status prompt text for insert mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟠');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.insert ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.insert
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.insert = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Visual mode prompt')
+      .setDesc('Set the status prompt text for visual mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟡');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.visual ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.visual
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.visual = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Replace mode prompt')
+      .setDesc('Set the status prompt text for replace mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🔴');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.replace ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.replace
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.replace = value;
+          this.plugin.saveSettings();
+        });
+      });
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -41,12 +41,7 @@ const DEFAULT_SETTINGS: Settings = {
 	vimModeStatusBarCSSClass: false,
 }
 
-const vimStatusPromptClassNameMap = {
-	normal: 'plugin-obsidian-vimrc-support-prompt-normal',
-	insert: 'plugin-obsidian-vimrc-support-prompt-insert',
-	visual: 'plugin-obsidian-vimrc-support-prompt-visual',
-	replace: 'plugin-obsidian-vimrc-support-prompt-replace',
-}
+const vimStatusPromptClass = "vimrc-support-vim-mode";
 
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
 const mappingCommands: String[] = [
@@ -75,8 +70,6 @@ export default class VimrcPlugin extends Plugin {
 	private vimChordStatusBar: HTMLElement = null;
 	private vimStatusBar: HTMLElement = null;
 	private currentVimStatus: vimStatus = vimStatus.normal;
-	private currentVimStatusClassName: string = 
-		vimStatusPromptClassNameMap[vimStatus.normal];
 	private customVimKeybinds: { [name: string]: boolean } = {};
 	private currentSelection: [EditorSelection] = null;
 	private isInsertMode: boolean = false;
@@ -86,17 +79,13 @@ export default class VimrcPlugin extends Plugin {
 			this.settings.vimStatusPromptMap[this.currentVimStatus]
 		);
 		if (this.settings.vimModeStatusBarCSSClass) {
-			document.querySelector('div.status-bar')?.classList.replace(
-				this.currentVimStatusClassName,
-				vimStatusPromptClassNameMap[this.currentVimStatus]
-			);
+			// When the setting is on, we also update vim status for the status bar
+			// container element.
+			(
+				document.querySelector("div.status-bar") as HTMLElement
+			).dataset.vimMode = this.currentVimStatus;
 		}
-		this.vimStatusBar?.classList.replace(
-			this.currentVimStatusClassName,
-			vimStatusPromptClassNameMap[this.currentVimStatus]
-		);
-		this.currentVimStatusClassName = 
-			vimStatusPromptClassNameMap[this.currentVimStatus];
+		this.vimStatusBar.dataset.vimMode = this.currentVimStatus;
 	}
 
 	async captureKeyboardLayout() {
@@ -626,13 +615,11 @@ export default class VimrcPlugin extends Plugin {
 				this.settings.vimStatusPromptMap[vimStatus.normal]
 			); // Init the vimStatusBar with normal mode
 			if (this.settings.vimModeStatusBarCSSClass) {
-				document.querySelector('div.status-bar')?.addClass(
-					vimStatusPromptClassNameMap[vimStatus.normal]
-				);
+				// When the setting is on, we also add the display prompt class to the
+				// status bar container element.
+				document.querySelector('div.status-bar').addClass(vimStatusPromptClass);
 			}
-			this.vimStatusBar?.addClass(
-				vimStatusPromptClassNameMap[vimStatus.normal]
-			); // Add the initial class name for normal mode
+			this.vimStatusBar.addClass(vimStatusPromptClass);
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -75,7 +75,7 @@ export default class VimrcPlugin extends Plugin {
 	private isInsertMode: boolean = false;
 
 	updateVimStatusBar() {
-		this.vimStatusBar?.setText(
+		this.vimStatusBar.setText(
 			this.settings.vimStatusPromptMap[this.currentVimStatus]
 		);
 		if (this.settings.vimModeStatusBarCSSClass) {
@@ -618,8 +618,12 @@ export default class VimrcPlugin extends Plugin {
 				// When the setting is on, we also add the display prompt class to the
 				// status bar container element.
 				document.querySelector('div.status-bar').addClass(vimStatusPromptClass);
+				(
+					document.querySelector('div.status-bar') as HTMLElement
+				).dataset.vimMode = this.currentVimStatus;
 			}
 			this.vimStatusBar.addClass(vimStatusPromptClass);
+			this.vimStatusBar.dataset.vimMode = this.currentVimStatus;
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,13 @@ const DEFAULT_SETTINGS: Settings = {
   },
 }
 
+const vimStatusPromptClassNameMap = {
+  normal: 'plugin-obsidian-vimrc-support-prompt-normal',
+  insert: 'plugin-obsidian-vimrc-support-prompt-insert',
+  visual: 'plugin-obsidian-vimrc-support-prompt-visual',
+  replace: 'plugin-obsidian-vimrc-support-prompt-replace',
+}
+
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
 const mappingCommands: String[] = [
 	"map",
@@ -66,9 +73,23 @@ export default class VimrcPlugin extends Plugin {
 	private vimChordStatusBar: HTMLElement = null;
 	private vimStatusBar: HTMLElement = null;
 	private currentVimStatus: vimStatus = vimStatus.normal;
+  private currentVimStatusClassName: string = 
+    vimStatusPromptClassNameMap[vimStatus.normal];
 	private customVimKeybinds: { [name: string]: boolean } = {};
 	private currentSelection: [EditorSelection] = null;
 	private isInsertMode: boolean = false;
+
+  updateVimStatusBar() {
+    this.vimStatusBar?.setText(
+      this.settings.vimStatusPromptMap[this.currentVimStatus]
+    );
+    this.vimStatusBar?.classList.replace(
+      this.currentVimStatusClassName,
+      vimStatusPromptClassNameMap[this.currentVimStatus]
+    );
+    this.currentVimStatusClassName = 
+      vimStatusPromptClassNameMap[this.currentVimStatus];
+  }
 
 	async captureKeyboardLayout() {
 		// This is experimental API and it might break at some point:
@@ -158,10 +179,7 @@ export default class VimrcPlugin extends Plugin {
 			this.isInsertMode = false;
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
-        this.vimStatusBar?.setText(
-          this.settings.vimStatusPromptMap[this.currentVimStatus]
-        );
-
+        this.updateVimStatusBar();
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
 
@@ -230,9 +248,7 @@ export default class VimrcPlugin extends Plugin {
 				break;
 		}
 		if (this.settings.displayVimMode)
-      this.vimStatusBar?.setText(
-        this.settings.vimStatusPromptMap[this.currentVimStatus]
-      );
+      this.updateVimStatusBar();
 	}
 
 	onunload() {
@@ -601,6 +617,9 @@ export default class VimrcPlugin extends Plugin {
       this.vimStatusBar.setText(
         this.settings.vimStatusPromptMap[vimStatus.normal]
       ); // Init the vimStatusBar with normal mode
+      this.vimStatusBar?.addClass(
+        vimStatusPromptClassNameMap[vimStatus.normal]
+      ); // Add the initial class name for normal mode
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -785,7 +785,7 @@ class SettingsTab extends PluginSettingTab {
 				})
 			});
 
-		containerEl.createEl('hr');
+		containerEl.createEl('h2', {text: 'Vim Mode Display Prompt'});
 
 		new Setting(containerEl)
 			.setName('Add Vim mode class to status bar')

--- a/main.ts
+++ b/main.ts
@@ -781,6 +781,8 @@ class SettingsTab extends PluginSettingTab {
 				})
 			});
 
+		containerEl.createEl('hr');
+
 		new Setting(containerEl)
 			.setName('Normal mode prompt')
 			.setDesc('Set the status prompt text for normal mode.')


### PR DESCRIPTION
Everything mentioned in the ealier issue (#177) are implemented. Viola!

## CSS Class Names
| Mode    | Class Name                                                                 |
| ------- | -------------------------------------------------- |
| normal  | `plugin-obsidian-vimrc-support-prompt-normal`  |
| insert  | `plugin-obsidian-vimrc-support-prompt-insert`      |
| visual  | `plugin-obsidian-vimrc-support-prompt-visual`      |
| replace | `plugin-obsidian-vimrc-support-prompt-replace` |

## Demo
- **Settings Page**
<img width="705" alt="Screen Shot 2023-03-27 at 15 54 23" src="https://user-images.githubusercontent.com/11176415/228084839-243387be-68a0-4c7c-bc16-8362756a0a94.png">

- **Custom Text**
<img width="707" alt="Screen Shot 2023-03-27 at 15 46 10" src="https://user-images.githubusercontent.com/11176415/228084698-6619f73b-ab14-4414-860e-b4ceec1e21f8.png">

- **Status Bar**
<img width="105" alt="Screen Shot 2023-03-27 at 14 46 27" src="https://user-images.githubusercontent.com/11176415/228081772-473eeafb-4609-4cbc-b7a3-52798b1eb53e.png">
<img width="123" alt="Screen Shot 2023-03-27 at 14 47 06" src="https://user-images.githubusercontent.com/11176415/228081774-604ab45d-3fca-4c75-ba07-24351673d71d.png">
<img width="109" alt="Screen Shot 2023-03-27 at 14 47 15" src="https://user-images.githubusercontent.com/11176415/228081777-cc991de3-941f-43b9-8978-56978f8a1a42.png">
<img width="116" alt="Screen Shot 2023-03-27 at 14 47 23" src="https://user-images.githubusercontent.com/11176415/228081779-8dcb6ace-048c-48cf-b8c8-7d6f64269de9.png">

- **Utilizing the CSS Classes**

Test with the CSS code below:

```css
.plugin-obsidian-vimrc-support-prompt-normal {
    color: red;
}
.plugin-obsidian-vimrc-support-prompt-insert {
    color: blue;
}
.plugin-obsidian-vimrc-support-prompt-visual {
    color: aqua;
}
.plugin-obsidian-vimrc-support-prompt-replace {
    color: green;
}
```

<img width="121" alt="Screen Shot 2023-03-27 at 15 20 21" src="https://user-images.githubusercontent.com/11176415/228079782-550203a7-d9d5-42ca-b051-1844bbc41667.png">
<img width="110" alt="Screen Shot 2023-03-27 at 15 20 15" src="https://user-images.githubusercontent.com/11176415/228079851-4116062a-e58e-4e63-a922-c56d0ac0c4ee.png">
<img width="117" alt="Screen Shot 2023-03-27 at 15 36 32" src="https://user-images.githubusercontent.com/11176415/228082433-5f24f81b-1895-4d3b-8213-86538c6f4745.png">
<img width="106" alt="Screen Shot 2023-03-27 at 15 36 41" src="https://user-images.githubusercontent.com/11176415/228082435-d84ba0cd-eed3-4dc8-ab39-8b6ef8f337d0.png">
