### PR TITLE
Add surround backticks to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Here's an example config that implements many of the features from vim-surround:
 exmap surround_wiki surround [[ ]]
 exmap surround_double_quotes surround " "
 exmap surround_single_quotes surround ' '
+exmap surround_backticks surround ` `
 exmap surround_brackets surround ( )
 exmap surround_square_brackets surround [ ]
 exmap surround_curly_brackets surround { }
@@ -161,6 +162,7 @@ nunmap s
 vunmap s
 map s" :surround_double_quotes
 map s' :surround_single_quotes
+map s` :surround_backticks
 map sb :surround_brackets
 map s( :surround_brackets
 map s) :surround_brackets


### PR DESCRIPTION
Extending the vim-surround example with backticks as it is used a lot.