### PR TITLE
chore: update readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In some cases you can find workarounds by experimenting, and the easiest way to 
 
 ## Installation
 
-In the Obsidian.md settings under "Third-party plugin", turn off Safe mode, then browse to this plugin.
+In the Obsidian.md settings under "Community plugins", click on "Turn on community plugins", then browse to this plugin.
 
 Alternatively (and less recommended), you can install it manually: just copy `main.js` and `manifest.json` to your vault `VaultFolder/.obsidian/plugins/obsidian-vimrc-support/`.
 


### PR DESCRIPTION
Updated wording of installation instructions to reflect the current UI of Obsidian, as there is no longer a "safe mode" and the settings tab has been renamed as well.

It's been quite a while since they've changed this, meaning the amount of users on a version of Obsidian that still says "safe mode"/"third party plugins" will be minimal, so I don't think there is need for instructions that would mention both options.

See current settings on a fresh install of Obsidian: 
![image](https://user-images.githubusercontent.com/50963023/236670371-877c80c6-9f13-4377-95aa-af2420cac830.png)
