### PR TITLE
Added more escape characters to surround

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -455,8 +455,8 @@ export default class VimrcPlugin extends Plugin {
 				throw new Error("surround requires exactly 2 parameters: prefix and postfix text.");
 			}
 
-			let beginning = newArgs[0].replace(/\\(.)/g, function(str, char) { return escapeCodes[char]; }); // Get the beginning surround text
-			let ending = newArgs[1].replace(/\\(.)/g, function(str, char) { return escapeCodes[char]; }); // Get the ending surround text
+			let beginning = newArgs[0].replace(/\\([\\rntsb &])/g, function(str, char) { return escapeCodes[char]; }); // Get the beginning surround text
+			let ending = newArgs[1].replace(/\\([\\rntsb &])/g, function(str, char) { return escapeCodes[char]; }); // Get the ending surround text
 
             let currentSelections = this.currentSelection;
 			var chosenSelection = currentSelections?.[0] ? currentSelections[0] : {anchor: editor.getCursor(), head: editor.getCursor()};

--- a/main.ts
+++ b/main.ts
@@ -51,6 +51,18 @@ const mappingCommands: String[] = [
 	"vunmap",
 ]
 
+
+const escapeCodes: { [key: string]: string } = {
+	'\\': '\\',
+	'r': '\r',
+	'n': '\n',
+	't': '\t',
+	's': ' ',
+	'b': '\b',
+	'&': '\&',
+	' ': ' '
+};
+
 function sleep(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -443,8 +455,8 @@ export default class VimrcPlugin extends Plugin {
 				throw new Error("surround requires exactly 2 parameters: prefix and postfix text.");
 			}
 
-			let beginning = newArgs[0].replace("\\\\", "\\").replace("\\ ", " "); // Get the beginning surround text
-			let ending = newArgs[1].replace("\\\\", "\\").replace("\\ ", " "); // Get the ending surround text
+			let beginning = newArgs[0].replace(/\\(.)/g, function(str, char) { return escapeCodes[char]; }); // Get the beginning surround text
+			let ending = newArgs[1].replace(/\\(.)/g, function(str, char) { return escapeCodes[char]; }); // Get the ending surround text
 
             let currentSelections = this.currentSelection;
 			var chosenSelection = currentSelections?.[0] ? currentSelections[0] : {anchor: editor.getCursor(), head: editor.getCursor()};


### PR DESCRIPTION
For example:
With this .obsidian.vimrc
```
exmap surround_backticks surround ```\n \n```
nunmap s
vunmap s
map s` :surround_backticks
```
Pressing s` creates a code block