### PR TITLE
Changed double "map s["

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ map sb :surround_brackets
 map s( :surround_brackets
 map s) :surround_brackets
 map s[ :surround_square_brackets
-map s[ :surround_square_brackets
+map s] :surround_square_brackets
 map s{ :surround_curly_brackets
 map s} :surround_curly_brackets
 ```


### PR DESCRIPTION
Just a little change regarding a potential typo.
There are two "map s[" in the demo config, one of which should be "map s]" if my understanding is correct.