### PR TITLE
Add a jssnippet to skip folds

### DIFF
--- a/JsSnippets.md
+++ b/JsSnippets.md
@@ -60,6 +60,26 @@ nmap ]] :nextHeading
 nmap [[ :prevHeading
 ```
 
+
+## Avoid unfolding folded sections
+```javascript
+function moveUpSkipFold() {
+  view.editor.exec('goUp');
+}
+function moveDownSkipFold() {
+  view.editor.exec('goDown');
+}
+```
+Then in your `.obsidian.vimrc` file add the following:
+
+```
+exmap upSkipFold jsfile mdHelpers.js {moveUpSkipFold()}
+exmap downSkipFold jsfile mdHelpers.js {moveDownSkipFold()}
+nmap k :upSkipFold
+nmap j :downSkipFold
+```
+
+
 ## Vimwiki-like link navigation
 
 This snippet allows to navigate next/previous links with Tab/Shift+Tab.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ If you understand the risks and choose to use this feature, turn on "Support JS 
 
 There are two ways to define JS-based commands.
 
+#### JSCommand - JSFunction
 **The `jscommand` Ex command** defines a JS function that has an `editor: Editor`, a `view: MarkdownView` and a `selection: EditorSelection` arguments (see the [Obsidian API](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts) if you're not sure what these are).
 You define only the body of the function, in a single line wrapped by curly braces, e.g.:
 
@@ -276,7 +277,10 @@ exmap logCursor jscommand { console.log(editor.getCursor()); }
 nmap <C-q> :logCursor
 ```
 
+#### JSCommand - JSFile
 Another version of the same functionality is **the `jsfile` Ex command**, which executes code from a file you give as a parameter, then appends another optional piece of code to it (e.g. in case you want to store several helper methods in a file and launch different ones as part of different commands).
+
+The `jsfile` should be placed in your vault (alongside, e.g., your markdown files).
 
 As above, the code running as part of `jsfile` has the arguments `editor: Editor`, `view: MarkdownView` and `selection: EditorSelection`.
 


### PR DESCRIPTION
When navigating with j/k, we often end up opening folded sections because of where the cursor ends up. 

This solves that problem.

## solution
Editor has goUp / goDown commands that seem to appropriately interact with the UI state.

## other solution attemps:
I tried a few methods
- vim function that would take the cursor to front of line, then move up, then go back to char position, but vim script functions seem not to work with vim codemirror
- using javascript to simulate keypress (arrowup/arrowdown) but obsidian did not respond

## examples of people with this issue
See e.g [obs forum](https://forum.obsidian.md/t/enable-vim-bindings-to-pass-over-folded-sections/57613)
[obs forum 2](https://forum.obsidian.md/t/folded-sections-lists-are-expanded-when-cursor-passes-them-in-vim-mode/14216)

## potential issues
- when in visual mode (V, then press j/k), sections will expand. This behavior is different from using arrow key + holding shift, where sections do not expand
- when I play with the above, sometimes Editor throws an error that multiple calls to the nav commands were passed and vim dies. The plugin itself should probably listen for errors, catch them, and console log them, rather than dying