### PR TITLE
fix README , validate gt and gT command without Tab Switcher plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,11 @@ nmap zR :unfoldall
 exmap foldall obcommand editor:fold-all
 nmap zM :foldall
 
-" Emulate Tab Switching https://vimhelp.org/tabpage.txt.html#gt
-" requires Cycle Through Panes Plugins https://obsidian.md/plugins?id=cycle-through-panes
-exmap tabnext obcommand cycle-through-panes:cycle-through-panes
+exmap tabnext obcommand workspace:next-tab
 nmap gt :tabnext
-exmap tabprev obcommand cycle-through-panes:cycle-through-panes-reverse
+exmap tabprev obcommand workspace:previous-tab
 nmap gT :tabprev
+
 ```
 
 ## Fixed Keyboard Layout in Normal Mode


### PR DESCRIPTION
Subject: Update to README for Tab Switching Functionality

Body:
Hello! Thank you for maintaining this plugin.
I have made some updates to the README.md regarding the tab switching functionality. Here are the changes:

Before:

```vim:
exmap tabnext obcommand cycle-through-panes:cycle-through-panes
nmap gt :tabnext
exmap tabprev obcommand cycle-through-panes:cycle-through-panes-reverse
nmap gT :tabprev
```

After
```vim:
exmap tabnext obcommand workspace:next-tab
nmap gt :tabnext
exmap tabprev obcommand workspace:previous-tab
nmap gT :tabprev
```

With these changes, I am now able to switch tabs without using the Tab Switcher plugin. Using `obcommand workspace:next-tab` and `obcommand workspace:previous-tab` allows for moving between tabs.

I also encountered issues with using cycle-through-panes for tab movement (even though I have the tab-switcher plugin installed). When checking with the developer tool and trying different commands such as `:obcommand cycle-through-panes:focus-right-sidebar`, it worked. However, when I typed `:obcommand cycle-through-panes:cycle-through-panes-reverse` and `:obcommand cycle-through-panes:cycle-through-panes`, nothing happened.

If you can confirm these changes are correct, I would appreciate it if you could update the documentation accordingly.
Thank you!