### PR TITLE
Fix: jumpToHeading shouldn't match within codeblocks (also improve jumpToLink a bit)

### DIFF
--- a/motions/jumpToHeading.ts
+++ b/motions/jumpToHeading.ts
@@ -1,19 +1,24 @@
-import { jumpToPattern } from "../utils/jumpToPattern";
+import { Editor as CodeMirrorEditor } from "codemirror";
+import { EditorPosition } from "obsidian";
+import { isWithinMatch, jumpToPattern } from "../utils/jumpToPattern";
 import { MotionFn } from "../utils/vimApi";
 
-const HEADING_REGEX = /^#+ /gm;
+/** Naive Regex for a Markdown heading (H1 through H6). "Naive" because it does not account for
+ * whether the match is within a codeblock (e.g. it could be a Python comment, not a heading).
+ */
+const NAIVE_HEADING_REGEX = /^#{1,6} /gm;
+
+/** Regex for a Markdown fenced codeblock, which begins with some number >=3 of backticks at the
+ * start of a line. It either ends on the nearest future line that starts with at least as many
+ * backticks (\1 back-reference), or extends to the end of the string if no such future line exists.
+ */
+const FENCED_CODEBLOCK_REGEX = /(^```+)(.*?^\1|.*)/gms;
 
 /**
  * Jumps to the repeat-th next heading.
  */
 export const jumpToNextHeading: MotionFn = (cm, cursorPosition, { repeat }) => {
-  return jumpToPattern({
-    cm,
-    cursorPosition,
-    repeat,
-    regex: HEADING_REGEX,
-    direction: "next",
-  });
+  return jumpToHeading({ cm, cursorPosition, repeat, direction: "next" });
 };
 
 /**
@@ -24,11 +29,47 @@ export const jumpToPreviousHeading: MotionFn = (
   cursorPosition,
   { repeat }
 ) => {
+  return jumpToHeading({ cm, cursorPosition, repeat, direction: "previous" });
+};
+
+/**
+ * Jumps to the repeat-th heading in the given direction.
+ *
+ * Under the hood, we use the naive heading regex to find all headings, and then filter out those
+ * that are within codeblocks. `codeblockMatches` is passed in a closure to avoid repeated
+ * computation.
+ */
+function jumpToHeading({
+  cm,
+  cursorPosition,
+  repeat,
+  direction,
+}: {
+  cm: CodeMirrorEditor;
+  cursorPosition: EditorPosition;
+  repeat: number;
+  direction: "next" | "previous";
+}): EditorPosition {
+  const codeblockMatches = findAllCodeblocks(cm);
+  const filterMatch = (match: RegExpExecArray) => !isMatchWithinCodeblock(match, codeblockMatches);
   return jumpToPattern({
     cm,
     cursorPosition,
     repeat,
-    regex: HEADING_REGEX,
-    direction: "previous",
+    regex: NAIVE_HEADING_REGEX,
+    filterMatch,
+    direction,
   });
-};
+}
+
+function findAllCodeblocks(cm: CodeMirrorEditor): RegExpExecArray[] {
+  const content = cm.getValue();
+  return [...content.matchAll(FENCED_CODEBLOCK_REGEX)];
+}
+
+function isMatchWithinCodeblock(
+  match: RegExpExecArray,
+  codeblockMatches: RegExpExecArray[]
+): boolean {
+  return codeblockMatches.some((codeblockMatch) => isWithinMatch(codeblockMatch, match.index));
+}

--- a/motions/jumpToLink.ts
+++ b/motions/jumpToLink.ts
@@ -1,13 +1,22 @@
 import { jumpToPattern } from "../utils/jumpToPattern";
 import { MotionFn } from "../utils/vimApi";
 
-const WIKILINK_REGEX_STRING = "\\[\\[[^\\]\\]]+?\\]\\]";
-const MARKDOWN_LINK_REGEX_STRING = "\\[[^\\]]+?\\]\\([^)]+?\\)";
-const LINK_REGEX_STRING = `${WIKILINK_REGEX_STRING}|${MARKDOWN_LINK_REGEX_STRING}`;
+const WIKILINK_REGEX_STRING = "\\[\\[.*?\\]\\]";
+const MARKDOWN_LINK_REGEX_STRING = "\\[.*?\\]\\(.*?\\)";
+const URL_REGEX_STRING = "\\w+://\\S+";
+
+/**
+ * Regex for a link (which can be a wikilink, a markdown link, or a standalone URL).
+ */
+const LINK_REGEX_STRING = `${WIKILINK_REGEX_STRING}|${MARKDOWN_LINK_REGEX_STRING}|${URL_REGEX_STRING}`;
 const LINK_REGEX = new RegExp(LINK_REGEX_STRING, "g");
 
 /**
  * Jumps to the repeat-th next link.
+ *
+ * Note that since `jumpToPattern` uses `String.matchAll`, which internally updates `lastIndex`
+ * after each match, it won't catch standalone URLs within wikilinks / markdown links
+ * (which should be a good thing in most cases).
 */
 export const jumpToNextLink: MotionFn = (cm, cursorPosition, { repeat }) => {
   return jumpToPattern({

--- a/motions/jumpToLink.ts
+++ b/motions/jumpToLink.ts
@@ -14,9 +14,10 @@ const LINK_REGEX = new RegExp(LINK_REGEX_STRING, "g");
 /**
  * Jumps to the repeat-th next link.
  *
- * Note that since `jumpToPattern` uses `String.matchAll`, which internally updates `lastIndex`
- * after each match, it won't catch standalone URLs within wikilinks / markdown links
- * (which should be a good thing in most cases).
+ * Note that `jumpToPattern` uses `String.matchAll`, which internally updates `lastIndex` after each
+ * match; and that `LINK_REGEX` matches wikilinks / markdown links first. So, this won't catch
+ * non-standalone URLs (e.g. the URL in a markdown link). This should be a good thing in most cases;
+ * otherwise it could be tedious (as a user) for each markdown link to contain two jumpable spots.
 */
 export const jumpToNextLink: MotionFn = (cm, cursorPosition, { repeat }) => {
   return jumpToPattern({


### PR DESCRIPTION
Finally got around to this :) thanks to @langshangyuan for filing https://github.com/esm7/obsidian-vimrc-support/issues/231! (And to @lebigot for noticing as well and commenting on #222)

# Summary

This PR does two things:
1. Fixes `jumpToHeading` to not match within code blocks (e.g. in the case of Python comments within a codeblock)
2. Improves `jumpToLink` to also be able to jump to standalone hyperlinks

# Implementation details

## jumpToHeading

### Initial approach - single regex with lookarounds

Initially I explored adjusting `HEADING_REGEX` to use lookarounds to ensure that a given match isn't inside a codeblock, as @langshangyuan suggested (it was a good idea). I did get something working, although it was a little complex:

`const HEADING_REGEX = /(?<=(?<!.)(?:(?:(?:(?!^```).)*?^```){2})*(?:(?!^```).)*)^#{1,6} /gms;`

The above regex matches on heading patterns (`^#{1,6} `) only if the lookbehind assertion passes. The lookbehind asserts that from the top of the string (note that in multiline mode `^` means "start of line", so we use `(?<!.)` to assert "start of string") up until the potential heading, there are an even number of codeblock markers.

I realized two issues though with this approach:

1. **It fails in the case that the code block starts with more than 3 backticks.** In Markdown, fenced codeblocks are allowed to start/end with _more than_ 3 backticks. E.g. this [GitHub article](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) notes you can use quadruple backticks to make a code block, and triple backticks within the codeblock will just be displayed rather than ending the codeblock. This [Python-Markdown article](https://python-markdown.github.io/extensions/fenced_code_blocks/) also notes that a fenced codeblock can start with any number >=3 of backticks, and must end with that many as well. Experimenting in Obsidian, you can see that a codeblock ends as long as its end marker has at least as many backticks as its start marker (otherwise the codeblock extends to the end of the document).

2. **Performance:** at each heading match, the lookbehind needs to traverse all the way from the top of the string until the match, to check that there are an even number of preceding code block markers.

### Actual implementation - two regexes (one for codeblocks, one for headings)

This approach helps with both issues above:

**More than three backticks:** While adjusting the lookbehind to account for >=3 backticks might have been possible, it would have made it even more complex/unreadable, which isn't great for codebase maintenance. With the two-regex approach, the codeblock regex on its own isn't too complex, while still accurate (ensuring each codeblock ends with at least as many backticks as it started with, or extends to the end of the document otherwise).

**Performance:** with this two-regex approach, we need two linear iterations (one for each regex) to get all codeblock matches and all "naive" heading matches. Then for each "naive" heading match, we check against all codeblock matches to make sure it's not in a codeblock. Technically this filter could still be non-linear ($O(N^2)$) time: say there are C codeblocks and H headers and the document is `N` lines long, then this filter takes $O(C\*H)$ time. In theory, if the document has a LOT of codeblocks and headers, we could have e.g. $C = H = N/3$ meaning $O(N^2/9)$ time. But in practice, most documents will have a more reasonable (closer to constant-level) number of codeblocks in them, so the $O(C\*H)$ filter should be much more efficient than a lookbehind that traverses from the start of the string until each naive heading match, for every naive heading match.

## jumpToLink

I'd been meaning to get around to this, so this was a good opportunity; I've now added a `URL_REGEX_STRING` subpattern to `LINK_REGEX` so that `jumpToLink` can also jump to standalone URLs. I used a simple `\w+://\S+` regex pattern, so this will match URLs like `chrome://extensions` or `file://<some_path>` or `https://google.com`.

# Screen recordings

## jumpToHeading


https://github.com/user-attachments/assets/7290feb7-92bc-442e-8f20-483479598ee1

## jumpToLink

https://github.com/user-attachments/assets/662f80f2-4e09-4494-8d39-6b6dc2c0e2ae


---

Thanks again for noticing this everyone! Let me know if anyone has any questions/comments/concerns/suggestions.