### PR TITLE
fix: guard against uninitialized codemirror instance

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -153,6 +153,7 @@ export default class VimrcPlugin extends Plugin {
 		if (!view) return;
 
 		let cm = this.getCodeMirror(view);
+		if (!cm) return;
 		if (
 			this.getCursorActivityHandlers(cm).some(
 				(e: { name: string }) => e.name === "updateSelection")
@@ -180,6 +181,8 @@ export default class VimrcPlugin extends Plugin {
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
 				this.updateVimStatusBar();
+
+			if (!cmEditor) return;
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
 
@@ -580,7 +583,9 @@ export default class VimrcPlugin extends Plugin {
 			this.vimChordStatusBar.parentElement.insertBefore(this.vimChordStatusBar, parent.firstChild);
 			this.vimChordStatusBar.style.marginRight = "auto";
 
-			let cmEditor = this.getCodeMirror(this.getActiveView());
+			const view = this.getActiveView();
+			if (!view) return;
+			let cmEditor = this.getCodeMirror(view);
 			// See https://codemirror.net/doc/manual.html#vimapi_events for events.
 			cmEditor.off('vim-keypress', this.onVimKeypress);
 			cmEditor.on('vim-keypress', this.onVimKeypress);


### PR DESCRIPTION
In obsidian (>=v1.7.2?) the codemirror instance is often not unitialized at times, triggering some uncaught exceptions. This is particularly noticable when:

- (w/ "Vim chord display" enabled) opening the vault w/o a note opened
- closing all tabs and opening a note

Add some null guards to avoid these errors

Fixes #237

<details>

<summary>Some examples of stacktraces caused by unitialized codemirror</summary>

Obsidian debug info:

```
Obsidian version: v1.7.4
Installer version: v1.7.4
Operating system: Darwin Kernel Version 24.0.0: Tue Sep 24 23:39:07 PDT 2024; root:xnu-11215.1.12~1/RELEASE_ARM64_T6000 24.0.0
Login status: logged in
Language: en
Catalyst license: supporter
Insider build toggle: on
Live preview: on
Base theme: adapt to system
Community theme: none
Snippets enabled: 0
Restricted mode: off
Plugins installed: 2
Plugins enabled: 2
	1: Homepage v4.0.7
	2: Vimrc Support v0.10.1
```

```
TypeError: Cannot read properties of null (reading 'editMode')
    at VimrcPlugin.getCodeMirror (plugin:obsidian-vimrc-support:755:21)
    at VimrcPlugin.prepareChordDisplay (plugin:obsidian-vimrc-support:1040:33)
    at VimrcPlugin.initialize (plugin:obsidian-vimrc-support:651:14)
    at eval (plugin:obsidian-vimrc-support:720:28)
    at e.tryTrigger (app.js:1:722881)
    at e.trigger (app.js:1:722814)
    at t.trigger (app.js:1:2371835)
    at t.activeLeafEvents (app.js:1:2356506)
    at l (app.js:1:518110)
    at c (app.js:1:518226)
```

```
TypeError: Cannot read properties of undefined (reading '_handlers')
    at VimrcPlugin.getCursorActivityHandlers (plugin:obsidian-vimrc-support:690:19)
    at VimrcPlugin.updateSelectionEvent (plugin:obsidian-vimrc-support:682:18)
    at eval (plugin:obsidian-vimrc-support:661:18)
    at e.tryTrigger (app.js:1:722881)
    at e.trigger (app.js:1:722814)
    at t.trigger (app.js:1:2371835)
    at t.activeLeafEvents (app.js:1:2356661)
    at l (app.js:1:518110)
    at c (app.js:1:518226)
```

```
TypeError: Cannot read properties of undefined (reading 'off')
    at VimrcPlugin.updateVimEvents (plugin:obsidian-vimrc-support:703:22)
    at eval (plugin:obsidian-vimrc-support:662:18)
    at e.tryTrigger (app.js:1:722881)
    at e.trigger (app.js:1:722814)
    at t.trigger (app.js:1:2371835)
    at t.activeLeafEvents (app.js:1:2356661)
    at l (app.js:1:518110)
    at c (app.js:1:518226)
```

</details>
