### PR TITLE
Fix `pasteinto` error when clipboard text has surrounding whitespace.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -521,7 +521,7 @@ export default class VimrcPlugin extends Plugin {
 			// Using the register for when this.yankToSystemClipboard == false
 			surroundFunc(
 				['[',
-				 '](' + vimObject.getRegisterController().getRegister('yank').keyBuffer + ")"]);
+				 '](' + vimObject.getRegisterController().getRegister('yank').keyBuffer[0].trim() + ")"]);
 		})
 
 		var editor = this.getActiveView().editor;


### PR DESCRIPTION
`pasteinto` is called by `surroundFunc` which splits a string into whitespace delimited arguments. Surrounding whitespace in the link to be pasted thus errors due to an unhandled number of arguments.

The now fixed error can be recreated by using `yy` to yank a line and then using <A-p> to paste the link over a word. Similarly, `yW` will reproduce the error if the link has trailing whitespace.

`pasteinto` will still error if the link contains internal whitespace, but this is more reasonable behavior. Fixing this will require tweaking the regex `surroundFunc` uses to split up arguments.